### PR TITLE
Add previous/next arrows to font control

### DIFF
--- a/src/shared/messaging/messages.ts
+++ b/src/shared/messaging/messages.ts
@@ -46,10 +46,7 @@ export interface CustomFontStorageResponse extends RuntimeAck {
 }
 
 export type RuntimeMessage =
-	| PopupToContentMessage
-	| ContentToPopupMessage
-	| CustomFontStorageMessage
-	| { type: 'PING' };
+	PopupToContentMessage | ContentToPopupMessage | CustomFontStorageMessage | { type: 'PING' };
 
 export interface RuntimeAck {
 	ok: boolean;

--- a/src/widgets/overlay-panel/font-combobox/font-combobox-view.ts
+++ b/src/widgets/overlay-panel/font-combobox/font-combobox-view.ts
@@ -4,6 +4,7 @@ import { classNames, h, removeChildren } from '../dom';
 import { icon } from '../icons';
 import { PopoverView } from '../components/popover-view';
 import { ScrollAreaView } from '../components/scroll-area-view';
+import { createButton } from '../settings/form-controls';
 
 export type FontEntry =
 	| (BundledFontEntry & { kind: 'bundled' })
@@ -26,7 +27,10 @@ export interface FontComboboxViewOptions {
 
 export class FontComboboxView {
 	public readonly element: HTMLButtonElement;
+	public readonly cycleControls: HTMLDivElement;
 	private readonly valueLabel: HTMLSpanElement;
+	private readonly previousButton: HTMLButtonElement;
+	private readonly nextButton: HTMLButtonElement;
 	private readonly searchInput: HTMLInputElement;
 	private readonly list: HTMLElement;
 	private readonly scrollArea: ScrollAreaView;
@@ -50,6 +54,15 @@ export class FontComboboxView {
 			this.valueLabel,
 			icon('chevron-down', 'tm-font-combobox__chevron')
 		);
+		this.previousButton = createButton('tm-button tm-button--ghost tm-button--glyph-nav', 'previous font');
+		this.previousButton.title = 'previous font';
+		this.previousButton.append(icon('arrow-left'));
+		this.previousButton.addEventListener('click', () => void this.selectAdjacent(-1));
+		this.nextButton = createButton('tm-button tm-button--ghost tm-button--glyph-nav', 'next font');
+		this.nextButton.title = 'next font';
+		this.nextButton.append(icon('arrow-right'));
+		this.nextButton.addEventListener('click', () => void this.selectAdjacent(1));
+		this.cycleControls = h('div', { className: 'tm-font-combobox__actions' }, this.previousButton, this.nextButton);
 		this.searchInput = h('input', {
 			className: 'tm-font-combobox__search tm-input',
 			attributes: {
@@ -136,6 +149,9 @@ export class FontComboboxView {
 		this.valueLabel.textContent = isDisabled
 			? 'No local fonts'
 			: (selectedFont?.displayName ?? fallbackLabel ?? 'System default');
+		const canCycle = this.fonts.length > 1 && !this.busy;
+		this.previousButton.disabled = !canCycle;
+		this.nextButton.disabled = !canCycle;
 		this.renderList();
 	}
 
@@ -234,14 +250,7 @@ export class FontComboboxView {
 			...children
 		);
 		option.addEventListener('click', () => {
-			void this.runBusy(async () => {
-				await this.options.onChange(font.id);
-				this.value = font.id;
-				this.query = '';
-				this.searchInput.value = '';
-				this.popover.setOpen(false);
-				this.render();
-			});
+			void this.selectFont(font);
 		});
 		return option;
 	}
@@ -279,6 +288,8 @@ export class FontComboboxView {
 		this.busy = true;
 		this.element.setAttribute('aria-busy', 'true');
 		this.element.disabled = true;
+		this.previousButton.disabled = true;
+		this.nextButton.disabled = true;
 		try {
 			await action();
 		} catch {
@@ -288,6 +299,27 @@ export class FontComboboxView {
 			this.element.removeAttribute('aria-busy');
 			this.render();
 		}
+	}
+
+	private async selectFont(font: FontEntry): Promise<void> {
+		await this.runBusy(async () => {
+			await this.options.onChange(font.id);
+			this.value = font.id;
+			this.query = '';
+			this.searchInput.value = '';
+			this.popover.setOpen(false);
+			this.render();
+		});
+	}
+
+	private async selectAdjacent(direction: -1 | 1): Promise<void> {
+		if (this.fonts.length < 2) return;
+		const currentIndex = this.fonts.findIndex((font) => font.id === this.value);
+		const baseIndex = currentIndex >= 0 ? currentIndex : 0;
+		const nextIndex = (baseIndex + direction + this.fonts.length) % this.fonts.length;
+		const font = this.fonts[nextIndex];
+		if (!font) return;
+		await this.selectFont(font);
 	}
 }
 

--- a/src/widgets/overlay-panel/overlay-settings-form-view.ts
+++ b/src/widgets/overlay-panel/overlay-settings-form-view.ts
@@ -133,7 +133,7 @@ export class OverlaySettingsFormView {
 			this.charColorModeField.element,
 			this.cellColorModeField.element,
 			this.glyphRampField.element,
-			createSettingField('font', this.fontCombobox.element)
+			createSettingField('font', this.fontCombobox.element, undefined, this.fontCombobox.cycleControls)
 		);
 		this.tabs.advancedContent.append(advancedControls);
 		this.postFxPanel = new PostFxPanelView({

--- a/src/widgets/overlay-panel/popup.css
+++ b/src/widgets/overlay-panel/popup.css
@@ -847,6 +847,13 @@ select {
 	max-width: 66%;
 }
 
+.tm-font-combobox__actions {
+	display: inline-flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 4px;
+}
+
 .tm-glyph-ramp-name {
 	min-width: 0;
 	max-width: 108px;

--- a/src/widgets/overlay-panel/settings/form-controls.ts
+++ b/src/widgets/overlay-panel/settings/form-controls.ts
@@ -27,12 +27,12 @@ export function createSettingField(
 	label: string,
 	child: HTMLElement,
 	className?: string,
-	output?: HTMLOutputElement
+	labelActions?: Node | string | null
 ): HTMLLabelElement {
 	return h(
 		'label',
 		{ className: classNames('tm-field', className) },
-		h('span', { className: 'tm-field__label' }, h('span', { textContent: label }), output ?? null),
+		h('span', { className: 'tm-field__label' }, h('span', { textContent: label }), labelActions ?? null),
 		child
 	);
 }

--- a/tests/unit/ui/font-combobox.test.ts
+++ b/tests/unit/ui/font-combobox.test.ts
@@ -97,6 +97,24 @@ describe('FontComboboxView', () => {
 		expect(onChange).toHaveBeenCalledWith('atascii');
 	});
 
+	it('cycles fonts through the previous/next controls', async () => {
+		const onChange = vi.fn();
+		const combobox = createCombobox({ onChange });
+		host.append(combobox.cycleControls, combobox.element);
+
+		host.querySelector<HTMLButtonElement>('button[aria-label="next font"]')?.click();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(onChange).toHaveBeenCalledWith('ursafont');
+		expect(combobox.element.textContent).toContain('UrsaFont');
+
+		host.querySelector<HTMLButtonElement>('button[aria-label="previous font"]')?.click();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(onChange).toHaveBeenLastCalledWith('bescii');
+		expect(combobox.element.textContent).toContain('BESCII');
+	});
+
 	it('keeps the previous selection when an async font change fails', async () => {
 		const onChange = vi.fn(async () => {
 			throw new Error('Font failed to load.');

--- a/tests/unit/ui/overlay-panel.test.ts
+++ b/tests/unit/ui/overlay-panel.test.ts
@@ -7,6 +7,7 @@ import {
 	type OverlayDescriptor,
 } from '../../../src/domain/overlay/overlay-settings';
 import { getAdjacentGlyphRampPreset } from '../../../src/domain/overlay/glyph-ramp-registry';
+import { getAvailableFonts } from '../../../src/shared/fonts/runtime-font-registry';
 import { OverlayPanelView } from '../../../src/widgets/overlay-panel/overlay-panel-view';
 
 describe('OverlayPanelView', () => {
@@ -126,6 +127,23 @@ describe('OverlayPanelView', () => {
 		nextGlyphRampButton!.click();
 
 		expect(onUpdateOverlay).toHaveBeenCalledWith('overlay-1', { glyphRamp: expectedPreset.glyphRamp });
+	});
+
+	it('cycles fonts from the advanced controls', () => {
+		const onUpdateOverlay = vi.fn();
+		const overlay = createOverlay();
+		const fonts = getAvailableFonts();
+		const currentIndex = fonts.findIndex((font) => font.id === overlay.settings.fontId);
+		const expectedFontId = fonts[(currentIndex + 1) % fonts.length]!.id;
+		const view = createView({ onUpdateOverlay });
+		view.update([overlay]);
+		host.append(view.element);
+
+		const nextFontButton = host.querySelector<HTMLButtonElement>('button[aria-label="next font"]');
+		expect(nextFontButton).not.toBeNull();
+		nextFontButton!.click();
+
+		expect(onUpdateOverlay).toHaveBeenCalledWith('overlay-1', { fontId: expectedFontId });
 	});
 
 	it('resets all overlay settings without removing persisted custom fonts', () => {


### PR DESCRIPTION
## Summary\n- add previous/next arrow buttons next to the font field label in advanced settings\n- wire arrows to cycle available fonts with wraparound using the same busy/async behavior as combobox selection\n- extend UI tests to cover font cycling from both combobox and overlay panel\n\n## Testing\n- npm run lint\n- npm run typecheck\n- npm run test\n- npm run build:chrome