### PR TITLE
chore(deps): update textmode tooling dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "textmode-ascii-overlay-extension",
-		"version": "1.3.0",
+			"version": "1.3.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18,8 +18,8 @@
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.62.1",
-				"@textmode/build": "^0.1.0",
-				"@textmode/lint": "^0.1.1",
+				"@textmode/build": "^0.1.1",
+				"@textmode/lint": "^0.1.2",
 				"@textmode/release": "^0.2.1",
 				"@types/chrome": "^0.2.7",
 				"@types/node": "^26.4.0",
@@ -1065,20 +1065,20 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.90.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.90.0.tgz",
-			"integrity": "sha512-51x9KxyTAN6guZOCd+lmcDdkhgdMdP/6iMMtg9dyhCWDc3+iSUyoB7f/9WAM/yGHmGFq25Vd6bXRR7CZcB+tog==",
+			"version": "0.97.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.97.0.tgz",
+			"integrity": "sha512-EP8uoFfh6+GsdGCduYtmWAW0h7AO+Ayik9Vh5YbA2r/3N6lmJKkCNZX+q3QBXC1K6ixjQ/9igF2b7WVvLm063g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.9",
-				"@typescript-eslint/types": "^8.65.0",
-				"comment-parser": "1.4.7",
+				"@typescript-eslint/types": "^8.69.0",
+				"comment-parser": "1.4.8",
 				"esquery": "^1.7.0",
-				"jsdoc-type-pratt-parser": "~7.3.0"
+				"jsdoc-type-pratt-parser": "~9.2.1"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
+				"node": "^22.22.2 || >=24.15.0"
 			}
 		},
 		"node_modules/@es-joy/resolve.exports": {
@@ -2607,16 +2607,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@textmode/build": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@textmode/build/-/build-0.1.0.tgz",
-			"integrity": "sha512-Q+5dqlhw83u/gq4YOhwcKvaEOlwMG/TXt2fZKsLHz4xa8QunfTJibjsXSNHlq/71TqsqpBTP02/OE8d35fsUGw==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@textmode/build/-/build-0.1.1.tgz",
+			"integrity": "sha512-/CGks2y68RF3arMeeGj2CC3eD99SIap4skDKJvnce4KEZMRzRMbMXMoNRWG2IwHaXB0oV4PgauS94qVvVM2fkA==",
 			"dev": true,
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@mapwhit/glsl-minify": "^1.0.0",
 				"@vitest/coverage-v8": "^4.1.10",
 				"jsdom": "^30.0.0",
-				"terser": "^5.46.1",
+				"terser": "^5.50.0",
 				"vite": "^8.1.3",
 				"vitest": "^4.1.10"
 			},
@@ -2628,20 +2628,20 @@
 			}
 		},
 		"node_modules/@textmode/lint": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@textmode/lint/-/lint-0.1.1.tgz",
-			"integrity": "sha512-7K0/uV73xh5cCGxvRvTttTf2r7gy5sB6zl7oUnBNTOacibII0krfEjkqZvfovqEpNa7Wak1h0J7xPv8UeozTzg==",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@textmode/lint/-/lint-0.1.2.tgz",
+			"integrity": "sha512-26pwLJUpx+YBjHTPS8dy2BaeHTxu/rLpG6GWDw8XW8+w8LnTu/z3B+IIrJNw+kVcxc4wlwGQO5MhjFAMJHc5dQ==",
 			"dev": true,
 			"license": "CC0-1.0",
 			"dependencies": {
 				"@eslint/js": "^10.0.1",
 				"eslint": "^10.7.0",
-				"eslint-plugin-jsdoc": "^63.3.1",
-				"globals": "^17.9.0",
+				"eslint-plugin-jsdoc": "^64.3.4",
+				"globals": "^17.11.0",
 				"markdownlint-cli2": "^0.23.0",
 				"markdownlint-cli2-formatter-default": "^0.0.6",
 				"prettier": "^3.9.5",
-				"typescript-eslint": "^8.66.0"
+				"typescript-eslint": "^8.69.0"
 			},
 			"bin": {
 				"textmode-lint": "src/cli/textmode-lint.mjs"
@@ -2852,17 +2852,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
-			"integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
+			"integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.68.0",
-				"@typescript-eslint/type-utils": "8.68.0",
-				"@typescript-eslint/utils": "8.68.0",
-				"@typescript-eslint/visitor-keys": "8.68.0",
+				"@typescript-eslint/scope-manager": "8.69.0",
+				"@typescript-eslint/type-utils": "8.69.0",
+				"@typescript-eslint/utils": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -2875,22 +2875,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.68.0",
+				"@typescript-eslint/parser": "^8.69.0",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
-			"integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+			"integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.68.0",
-				"@typescript-eslint/types": "8.68.0",
-				"@typescript-eslint/typescript-estree": "8.68.0",
-				"@typescript-eslint/visitor-keys": "8.68.0",
+				"@typescript-eslint/scope-manager": "8.69.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2906,14 +2906,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
-			"integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+			"integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.68.0",
-				"@typescript-eslint/types": "^8.68.0",
+				"@typescript-eslint/tsconfig-utils": "^8.69.0",
+				"@typescript-eslint/types": "^8.69.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2928,14 +2928,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
-			"integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+			"integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.68.0",
-				"@typescript-eslint/visitor-keys": "8.68.0"
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2946,9 +2946,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
-			"integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+			"integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2963,15 +2963,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
-			"integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
+			"integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.68.0",
-				"@typescript-eslint/typescript-estree": "8.68.0",
-				"@typescript-eslint/utils": "8.68.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0",
+				"@typescript-eslint/utils": "8.69.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -2988,9 +2988,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
-			"integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+			"integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3002,16 +3002,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
-			"integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+			"integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.68.0",
-				"@typescript-eslint/tsconfig-utils": "8.68.0",
-				"@typescript-eslint/types": "8.68.0",
-				"@typescript-eslint/visitor-keys": "8.68.0",
+				"@typescript-eslint/project-service": "8.69.0",
+				"@typescript-eslint/tsconfig-utils": "8.69.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -3030,16 +3030,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
-			"integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+			"integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.68.0",
-				"@typescript-eslint/types": "8.68.0",
-				"@typescript-eslint/typescript-estree": "8.68.0"
+				"@typescript-eslint/scope-manager": "8.69.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3054,13 +3054,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
-			"integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+			"integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.68.0",
+				"@typescript-eslint/types": "8.69.0",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -3903,13 +3903,13 @@
 			"license": "MIT"
 		},
 		"node_modules/are-docs-informative": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
-			"integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.1.1.tgz",
+			"integrity": "sha512-sqRsNQBwbKLRX0jV5Cu5uzmtflf892n4Vukz7T659ebL4pz3mpOqCMU7lxMoBTFwnp10E3YB5ZcyHM41W5bcDA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/argparse": {
@@ -4953,9 +4953,9 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
-			"integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.8.tgz",
+			"integrity": "sha512-rKZTGo4fzKYna8UcL0isTg5wkBNla7bxTypLwZQXjIdi++IdP1OJ41rI5Mti3/jltkPujbu4i9LIARYA+zpotQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6046,18 +6046,19 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "63.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.1.tgz",
-			"integrity": "sha512-yVyTPtOY2tA8EjTwUtaM3pFxj9i/3m4/FSPMv5gMnDHSSleCpzIYQLyV8KnVmEIkkPpNhDlkDQ99mTfjxgqLxA==",
+			"version": "64.3.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-64.3.6.tgz",
+			"integrity": "sha512-lo7IXmgUUNy88SxW7KnJmmD2iPQBIRMomfCFPHidW1M3zNNVuzxlB2uoNrNyE1g4v2/L+RtYmiROPwQhSNzL8Q==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.90.0",
+				"@es-joy/jsdoccomment": "~0.97.0",
 				"@es-joy/resolve.exports": "1.2.0",
-				"are-docs-informative": "^0.0.2",
-				"comment-parser": "1.4.7",
+				"@typescript-eslint/utils": "^8.69.0",
+				"are-docs-informative": "^0.1.1",
+				"comment-parser": "1.4.8",
 				"debug": "^4.4.3",
-				"escape-string-regexp": "^4.0.0",
+				"escape-string-regexp": "^5.0.0",
 				"espree": "^11.2.0",
 				"esquery": "^1.7.0",
 				"html-entities": "^2.6.0",
@@ -6068,10 +6069,23 @@
 				"to-valid-identifier": "^1.0.0"
 			},
 			"engines": {
-				"node": "^22.13.0 || >=24"
+				"node": "^22.22.2 || >=24.15.0"
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint-plugin-no-unsanitized": {
@@ -7535,13 +7549,17 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.3.0.tgz",
-			"integrity": "sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-9.2.1.tgz",
+			"integrity": "sha512-V4Ww4EHnTcTLSOMoB0FsF72JhQvcAsriCm/LWnxJeGWoxIjEL2l9na11abQok5SYShq8m0Gl02el/xAbTCulvQ==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.9",
+				"@types/node": "^26.4.0"
+			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": "^22.22.2 || >=24.15.0"
 			}
 		},
 		"node_modules/jsdom": {
@@ -14374,16 +14392,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.68.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.68.0.tgz",
-			"integrity": "sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==",
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
+			"integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.68.0",
-				"@typescript-eslint/parser": "8.68.0",
-				"@typescript-eslint/typescript-estree": "8.68.0",
-				"@typescript-eslint/utils": "8.68.0"
+				"@typescript-eslint/eslint-plugin": "8.69.0",
+				"@typescript-eslint/parser": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0",
+				"@typescript-eslint/utils": "8.69.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.62.1",
-		"@textmode/build": "^0.1.0",
-		"@textmode/lint": "^0.1.1",
+		"@textmode/build": "^0.1.1",
+		"@textmode/lint": "^0.1.2",
 		"@textmode/release": "^0.2.1",
 		"@types/chrome": "^0.2.7",
 		"@types/node": "^26.4.0",


### PR DESCRIPTION
## Summary

Updates `@textmode` tooling dependencies to the latest published releases:

- **`@textmode/build`** (`^0.1.1`): Updated minification tooling (`terser` 5.50.0).
- **`@textmode/lint`** (`^0.1.2`): Upgraded `typescript-eslint` (8.69.0), `eslint-plugin-jsdoc` (64.3.4), and `globals` (17.11.0).

## Verification

- Dependencies updated in `package.json` and lockfile refreshed (`npm install`).
- Verification command executed: `npm run check` (passed).